### PR TITLE
Add plugin directories to fpath

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -54,6 +54,9 @@ fi
     if [[ ! "${ZGEN_LOADED[@]}" =~ ${file} ]]; then
         ZGEN_LOADED+="${file}"
     fi
+
+    # Add to $fpath, for completion(s).
+    fpath=($(dirname ${file}) $fpath)
 }
 
 zgen-update() {


### PR DESCRIPTION
- When we source a plugin file, add the file's enclosing directory to `$fpath`. This allows plugins that include completion functions that aren't in the core plugin file to still work.
- Add `zgen selfupdate` function (sorry, that probably should have been a separate PR)

Closes #3.
