### PR TITLE
Add `zgen completions` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,18 @@ A light plugin manager for zsh inspired by Antigen.
 
 `zgen oh-my-zsh <script>` shortcut for the command below
 
+`zgen completions <github repo> <subdirectory>` clone the repo, then add it (or <subdirectory>, if you gave it that argument) to fpath. Useful for repositories that don't have proper plugin support like `zsh-users/zsh-completions`.
+
 `zgen load <github repo> <script>` clone the repo and run the script
 
 `zgen save` save all loaded scripts into an init script so they'll get run each time you source zgen
 
 `zgen saved` returns 0 if there's an init script
 
+`zgen selfupdate` update zgen framework
+
 `zgen update` update all repositories and remove the init script
+
 
 ## Example .zshrc
 
@@ -37,6 +42,10 @@ if ! zgen saved; then
     zgen oh-my-zsh plugins/sudo
     zgen load zsh-users/zsh-syntax-highlighting
     zgen load /path/to/super-secret-private-plugin
+
+    # completion-only repositories. Add optional path argument to specify
+    # what subdirectory of the repository to add to your fpath.
+    zgen completions zsh-users/zsh-completions src
 
     # theme
     zgen oh-my-zsh themes/arrow

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -88,6 +88,33 @@ zgen-save() {
     echo "fpath=(\$fpath $ZGEN_COMPLETIONS )" >> "${ZGEN_INIT}"
 }
 
+zgen-completions() {
+    local repo=${1}
+    local dir=$(-zgen-get-clone-dir "${repo}")
+
+    if [[ -z "${2}" ]]; then
+        local completion_path="${dir}"
+    else
+        local completion_path="${dir}/${2}"
+    fi
+
+    # clone repo if not present
+    if [[ ! -d "${dir}" ]]; then
+        -zgen-clone "${repo}" "${dir}"
+    fi
+
+    if [[ -d "${completion_path}" ]]; then
+        # Add the directory to ZGEN_COMPLETIONS array unless already present
+        if [[ ! "${ZGEN_COMPLETIONS[@]}" =~ ${completion_path} ]]; then
+            ZGEN_COMPLETIONS+="${completion_path}"
+        fi
+    else
+        if [[ ! -z "${2}" ]]; then
+            echo "Could not find ${2} in ${repo}"
+        fi
+    fi
+}
+
 zgen-load() {
     local repo=${1}
     local file=${2}
@@ -156,7 +183,7 @@ zgen-oh-my-zsh() {
 zgen() {
     local cmd="${1}"
     if [[ -z "${cmd}" ]]; then
-        echo "usage: zgen [load|oh-my-zsh|save|selfupdate|update]"
+        echo "usage: zgen [completions|load|oh-my-zsh|save|selfupdate|update]"
         return 1
     fi
 


### PR DESCRIPTION
- Switch to using  `${ZGEN_COMPLETIONS}` array. This is more consistent with the way plugin files are handled. It will also made it easier to add the `zgen completions command`. `${ZGEN_INIT}` is also a lot tidier since we can just add `${ZGEN_COMPLETIONS}` to `fpath` in one line.
- Add `zgen completions` command. Some repositories contain completion functions, but aren't formatted as
  standard zsh plugins, like `zsh-users/zsh-completions`, which makes `zgen load` error out when it can't find a plugin file. `zgen completions <optional subdirectory>` will clone a repo and add it (or the subdirectory) to $fpath.
- Document `zgen selfupdate` command.
