### PR TITLE
Fix: Zgen fails to self-update when installed as a Git submodule

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -169,7 +169,7 @@ zgen-saved() {
 }
 
 zgen-selfupdate() {
-    if [ -d "${ZGEN_SOURCE}/.git" ]; then
+    if [ -e "${ZGEN_SOURCE}/.git" ]; then
         (cd "${ZGEN_SOURCE}" \
             && git pull)
     else


### PR DESCRIPTION
I have a repo for my dotfiles, which includes some tools as Git submodules. In this scenario `$ zgen selfupdate` fails because it checks wether `.git` is a directory. But as a submodule, `.git` is actually a file.

This PR checks if `.git` exists as a directory or a file.