### PR TITLE
Streamlined functions

### DIFF
--- a/_zgen
+++ b/_zgen
@@ -1,0 +1,14 @@
+local -a _zgen_commands
+_zgen_commands=(
+    "clone:clone plugins from repository"
+    "completions:deprecated, please use load instead"
+    "list:print init.zsh"
+    "load:clone and load plugins and completions"
+    "oh-my-zsh:load oh-my-zsh base"
+    "reset:delete the init.zsh script"
+    "save:check for init.zsh script"
+    "selfupdate:update zgen framework from repository"
+    "update:update all repositories and remove the init script"
+)
+
+_describe -t commands "zgen subcommand" _zgen_commands

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -220,22 +220,10 @@ zgen() {
     fi
 }
 
-_zgen() {
-    compadd \
-        clone \
-        completions \
-        list \
-        load \
-        oh-my-zsh \
-        reset \
-        save \
-        selfupdate \
-        update
-}
-
+ZGEN_SOURCE="$(dirname ${0})"
 ZSH="$(-zgen-get-clone-dir robbyrussell/oh-my-zsh master)"
 zgen-init
 
 autoload -U compinit
 compinit -d "${ZGEN_DIR}/zcompdump"
-compdef _zgen zgen
+fpath=($ZGEN_SOURCE $fpath)

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -1,3 +1,4 @@
+#!/bin/zsh
 local ZGEN_SOURCE="$(dirname ${0})"
 
 if [[ -z "${ZGEN_DIR}" ]]; then
@@ -37,15 +38,16 @@ fi
     fi
 }
 
--zgen-clone() {
+zgen-clone() {
     local repo="${1}"
-    local dir="${2}"
-    local branch="${3:-master}"
+    local branch="${2:-master}"
     local url="$(-zgen-get-clone-url ${repo})"
+    local dir="$(-zgen-get-clone-dir ${repo} ${branch})"
 
-    mkdir -p "${dir}"
-    git clone --recursive -b "${branch}" "${url}" "${dir}"
-    echo
+    if [[ ! -d "${dir}" ]]; then
+        mkdir -p "${dir}"
+        git clone --recursive -b "${branch}" "${url}" "${dir}"
+    fi
 }
 
 -zgen-add-to-fpath() {
@@ -72,22 +74,31 @@ fi
     -zgen-add-to-fpath "${completion_path}"
 }
 
-zgen-update() {
-    for repo in "${ZGEN_DIR}"/*/*; do
-        (cd "${repo}" \
-            && git pull \
-            && git submodule update --recursive)
-    done
+zgen-init() {
+    if [[ -f "${ZGEN_INIT}" ]]; then
+        source "${ZGEN_INIT}"
+    fi
+}
 
+zgen-reset() {
+    echo "zgen: Deleting ${ZGEN_INIT}"
     if [[ -f "${ZGEN_INIT}" ]]; then
         rm "${ZGEN_INIT}"
     fi
 }
 
+zgen-update() {
+    for repo in "${ZGEN_DIR}"/*/*; do
+        echo "Updating ${repo}"
+        (cd "${repo}" \
+            && git pull \
+            && git submodule update --recursive)
+    done
+    zgen-reset
+}
+
 zgen-save() {
-    if [[ -f "${ZGEN_INIT}" ]]; then
-        rm "${ZGEN_INIT}"
-    fi
+    zgen-init
 
     echo "zgen: Creating ${ZGEN_INIT}"
 
@@ -125,7 +136,7 @@ zgen-load() {
 
     # clone repo if not present
     if [[ ! -d "${dir}" ]]; then
-        -zgen-clone "${repo}" "${dir}" "${branch}"
+        zgen-clone "${repo}" "${branch}"
     fi
 
     # source the file
@@ -168,6 +179,14 @@ zgen-saved() {
     [[ -f "${ZGEN_INIT}" ]] && return 0 || return 1
 }
 
+zgen-list() {
+    if [[ -f "${ZGEN_INIT}" ]]; then
+        cat "${ZGEN_INIT}"
+    else
+        echo "Zgen init.zsh missing, please use zgen save and then restart your shell."
+    fi
+}
+
 zgen-selfupdate() {
     if [ -e "${ZGEN_SOURCE}/.git" ]; then
         (cd "${ZGEN_SOURCE}" \
@@ -188,7 +207,7 @@ zgen-oh-my-zsh() {
 zgen() {
     local cmd="${1}"
     if [[ -z "${cmd}" ]]; then
-        echo "usage: zgen [completions|load|oh-my-zsh|save|selfupdate|update]"
+        echo "usage: zgen [completions|load|oh-my-zsh|save|selfupdate|update|reset]"
         return 1
     fi
 
@@ -203,18 +222,19 @@ zgen() {
 
 _zgen() {
     compadd \
+        clone \
         completions \
+        list \
         load \
         oh-my-zsh \
+        reset \
         save \
         selfupdate \
         update
 }
 
 ZSH="$(-zgen-get-clone-dir robbyrussell/oh-my-zsh master)"
-if [[ -f "${ZGEN_INIT}" ]]; then
-    source "${ZGEN_INIT}"
-fi
+zgen-init
 
 autoload -U compinit
 compinit -d "${ZGEN_DIR}/zcompdump"

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -98,7 +98,7 @@ zgen-update() {
 }
 
 zgen-save() {
-    zgen-init
+    zgen-reset
 
     echo "zgen: Creating ${ZGEN_INIT}"
 
@@ -207,7 +207,7 @@ zgen-oh-my-zsh() {
 zgen() {
     local cmd="${1}"
     if [[ -z "${cmd}" ]]; then
-        echo "usage: zgen [completions|load|oh-my-zsh|save|selfupdate|update|reset]"
+        echo "usage: zgen [clone|completions|list|load|oh-my-zsh|reset|save|selfupdate|update]"
         return 1
     fi
 


### PR DESCRIPTION
1. Made zgen-clone function accessible, in case user simply wants to clone a repository while not loading it into init.zsh (for archival purposes)
2. Added zgen-reset function which simply deletes init.zsh
3. Streamlined zgen-update to use zgen-reset after finishing update
4. Added zgen-init to supress code duplication
5. Added zgen-list function which prints init.zsh on screen
6. Created completion function _zgen, pointed to fpath and adjusted completion accordingly