### PR TITLE
Added ability to use full repo urls.

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -18,6 +18,15 @@ if [[ -z "${ZGEN_COMPLETIONS}" ]]; then
     ZGEN_COMPLETIONS=()
 fi
 
+-zgen-encode-url () {
+    # Remove characters from a url that don't work well in a filename.
+    # Inspired by -anti-get-clone-dir() method from antigen.
+    echo "$1" | sed \
+            -e 's./.-SLASH-.g' \
+            -e 's.:.-COLON-.g' \
+            -e 's.|.-PIPE-.g'
+}
+
 -zgen-get-clone-dir() {
     local repo="${1}"
     local branch="${2:-master}"
@@ -25,6 +34,12 @@ fi
     if [[ -d "${repo}/.git" ]]; then
         echo "${ZGEN_DIR}/local/$(basename ${repo})-${branch}"
     else
+        # Repo directory will be location/reponame
+        local reponame="$(basename ${repo})"
+        # Need to encode incase it is a full url with characters that don't
+        # work well in a filename.
+        local location="$(-zgen-encode-url $(dirname ${repo}))"
+        repo="${location}/${reponame}"
         echo "${ZGEN_DIR}/${repo}-${branch}"
     fi
 }

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -35,7 +35,18 @@ fi
     if [[ -d "${repo}/.git" ]]; then
         echo "${repo}"
     else
-        echo "https://github.com/${repo}.git"
+        # Sourced from antigen url resolution logic.
+        # https://github.com/zsh-users/antigen/blob/master/antigen.zsh
+        # Expand short github url syntax: `username/reponame`.
+        if [[ $repo != git://* &&
+              $repo != https://* &&
+              $repo != http://* &&
+              $repo != ssh://* &&
+              $repo != git@github.com:*/*
+              ]]; then
+            repo="https://github.com/${repo%.git}.git"
+        fi
+        echo "${repo}"
     fi
 }
 


### PR DESCRIPTION
Plugins can now be specified with the full url of the repo rather than assuming it is hosted at github.

Example:

    zgen load https://gist.github.com/cledoux/d02ffc0b8aa500a70595 agnoster

Previous short form specification of github repos as well as local repo detection still works.