### PR TITLE
Copied Antigen's antigen-bundles as zgen-loadall

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ if ! zgen saved; then
     zgen load zsh-users/zsh-syntax-highlighting
     zgen load /path/to/super-secret-private-plugin
 
+    # bulk load
+    zgen loadall <<EOPLUGINS
+        zsh-users/zsh-history-substring-search
+        /path/to/local/plugin
+EOPLUGINS
+    # ^ can't indent this EOPLUGINS
+
     # completions
     zgen load zsh-users/zsh-completions src
 

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -203,6 +203,22 @@ zgen-load() {
     fi
 }
 
+zgen-loadall() {
+    # shameless copy from antigen
+
+    # Bulk add many bundles at one go. Empty lines and lines starting with a `#`
+    # are ignored. Everything else is given to `zgen-load` as is, no
+    # quoting rules applied.
+
+    local line
+
+    grep '^[[:space:]]*[^[:space:]#]' | while read line; do
+        # Using `eval` so that we can use the shell-style quoting in each line
+        # piped to `antigen-bundles`.
+        eval "zgen-load $line"
+    done
+}
+
 zgen-saved() {
     [[ -f "${ZGEN_INIT}" ]] && return 0 || return 1
 }


### PR DESCRIPTION
Shamelessly copied antigen-bundle as zgen-loadall, but Antigen is MIT licensed so it's OK as far as I understand.