### PR TITLE
Faster `git clone`

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -73,7 +73,7 @@ zgen-clone() {
 
     if [[ ! -d "${dir}" ]]; then
         mkdir -p "${dir}"
-        git clone --recursive -b "${branch}" "${url}" "${dir}"
+        git clone --depth=1 --recursive -b "${branch}" "${url}" "${dir}"
     fi
 }
 


### PR DESCRIPTION
We shouldn't clone the entire git history. Instead we clone only the latest commit. This will make cloning progress more faster.