### PR TITLE
Add more options to zgen

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -18,6 +18,18 @@ if [[ -z "${ZGEN_COMPLETIONS}" ]]; then
     ZGEN_COMPLETIONS=()
 fi
 
+if [[ -z "${ZGEN_OH_MY_ZSH_REPO}" ]]; then
+    ZGEN_OH_MY_ZSH_REPO=robbyrussell
+fi
+
+if [[ "${ZGEN_OH_MY_ZSH_REPO}" != */* ]]; then
+    ZGEN_OH_MY_ZSH_REPO="${ZGEN_OH_MY_ZSH_REPO}/oh-my-zsh"
+fi
+
+if [[ -z "${ZGEN_OH_MY_ZSH_BRANCH}" ]]; then
+    ZGEN_OH_MY_ZSH_BRANCH=master
+fi
+
 -zgen-encode-url () {
     # Remove characters from a url that don't work well in a filename.
     # Inspired by -anti-get-clone-dir() method from antigen.
@@ -153,11 +165,15 @@ zgen-completions() {
 }
 
 zgen-load() {
-    local repo="${1}"
-    local file="${2}"
-    local branch="${3:-master}"
-    local dir="$(-zgen-get-clone-dir ${repo} ${branch})"
-    local location="${dir}/${file}"
+    if [[ "$#" == 1 && ("${1[1]}" == '/' || "${1[1]}" == '.' ) ]]; then
+      local location="${1}"
+    else
+      local repo="${1}"
+      local file="${2}"
+      local branch="${3:-master}"
+      local dir="$(-zgen-get-clone-dir ${repo} ${branch})"
+      local location="${dir}/${file}"
+    fi
 
     # clone repo if not present
     if [[ ! -d "${dir}" ]]; then
@@ -199,7 +215,7 @@ zgen-load() {
         -zgen-add-to-fpath "${location}"
 
     else
-        echo "zgen: Failed to load ${dir}"
+        echo "zgen: Failed to load ${dir:-$location}"
     fi
 }
 
@@ -226,7 +242,7 @@ zgen-selfupdate() {
 }
 
 zgen-oh-my-zsh() {
-    local repo="robbyrussell/oh-my-zsh"
+    local repo="$ZGEN_OH_MY_ZSH_REPO"
     local file="${1:-oh-my-zsh.sh}"
 
     zgen-load "${repo}" "${file}"
@@ -248,7 +264,7 @@ zgen() {
     fi
 }
 
-ZSH="$(-zgen-get-clone-dir robbyrussell/oh-my-zsh master)"
+ZSH="$(-zgen-get-clone-dir "$ZGEN_OH_MY_ZSH_REPO" "$ZGEN_OH_MY_ZSH_BRANCH")"
 zgen-init
 fpath=($ZGEN_SOURCE $fpath)
 

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -157,8 +157,13 @@ zgen-save() {
     echo "#" >> "${ZGEN_INIT}"
     echo "fpath=(${(q)ZGEN_COMPLETIONS[@]} \${fpath})" >> "${ZGEN_INIT}"
 
-    echo "zgen: Creating ${ZGEN_DIR}/zcompdump"
-    compinit -d "${ZGEN_DIR}/zcompdump"
+    zgen-apply --verbose
+}
+
+zgen-apply() {
+  fpath=(${(q)ZGEN_COMPLETIONS[@]} ${fpath})
+  [[ "$1" == --verbose ]] && echo "zgen: Creating ${ZGEN_DIR}/zcompdump"
+  compinit -d "${ZGEN_DIR}/zcompdump"
 }
 
 zgen-completions() {


### PR DESCRIPTION
Each commit could be its own pull request. Basically, this makes 4 changes:

1. Allows use of a different oh-my-zsh source. I used it for my source, since there was one major customization in my branch that I was waiting to get merged. Personally, I don't need this change anymore, but it'll probably come in handy for other people.
2. Allows use of local plugins, without cloning a git repo. I mainly use this in my dotfiles to load opam as a plugin, instead of manually sourcing it. And it seems kind of odd to clone local repositories.
3. Splits out a zgen-apply function from zgen-load. Partly, this is a minor refactor, but this is also useful for users initially setting up their shell, so that they can use zgen-apply to start, add and remove different plugins and then switch to using zgen-load only once they have everything set up.
4. Some minor performance improvements. Especially on cygwin, running anything in a different process (grep, sed, awk, ls) is really slow. Luckily, the cache mitigates this, and I can revert that change if needed.
