### PR TITLE
Added possibility to chech for filechange on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Returns 0 if an init script exists.
 #### Update all repositories and remove the init script
     zgen update
 
+#### Automatically check for filechanges and regenerate zinit
+You can set the environment variable ZGEN_RESET_ON_CHANGE. These files will be checked and if a change is detected zgen reset is called.
+    ZGEN_RESET_ON_CHANGE=(${HOME}/.zshrc ${HOME}/.zshrc.local)
+
 ### Example .zshrc
 
 ```zsh

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -157,6 +157,22 @@ zgen-save() {
     echo "#" >> "${ZGEN_INIT}"
     echo "fpath=(${(q)ZGEN_COMPLETIONS[@]} \${fpath})" >> "${ZGEN_INIT}"
 
+    # check for file changes
+    if [[ ! -z ${ZGEN_RESET_ON_CHANGE} ]]; then
+       echo >> "${ZGEN_INIT}"
+       echo "# check for file changes" >> "${ZGEN_INIT}"
+       for file in ${ZGEN_RESET_ON_CHANGE}; do
+          CHANGESHA=`shasum -a 256 ${file}`
+          echo "if [[ \"\`shasum -a 256 ${file}\`\" != \"$CHANGESHA\" ]]; then" >> "${ZGEN_INIT}"
+          echo "   echo Changed file ${file}, resetting zgen" >> "${ZGEN_INIT}"
+          echo "   zgen reset" >> "${ZGEN_INIT}"
+          echo -n "el" >> "${ZGEN_INIT}"
+       done
+       echo "se " >> "${ZGEN_INIT}"
+       echo "   ;" >> "${ZGEN_INIT}"
+       echo "fi" >> "${ZGEN_INIT}"
+    fi
+
     zgen-apply --verbose
 }
 


### PR DESCRIPTION
This addition wiill automatically check for changes in .zshrc (or another file defined) and perform a reset after initialization.

To enable the feature set the value of ```ZGEN_RESET_ON_CHANGE``` to e.g. ```${HOME}/.zshrc``` before sourcing zgen.