### PR TITLE
Allow to disable compinit

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -298,5 +298,8 @@ ZSH="$(-zgen-get-clone-dir "$ZGEN_OH_MY_ZSH_REPO" "$ZGEN_OH_MY_ZSH_BRANCH")"
 zgen-init
 fpath=($ZGEN_SOURCE $fpath)
 
-autoload -U compinit
-compinit -d "${ZGEN_DIR}/zcompdump"
+ZGEN_AUTOLOAD_COMPINIT=${ZGEN_AUTOLOAD_COMPINIT:-true}
+if $ZGEN_AUTOLOAD_COMPINIT; then
+    autoload -U compinit
+    compinit -d "${ZGEN_DIR}/zcompdump"
+fi


### PR DESCRIPTION
Implement ZGEN_AUTOLOAD_COMPINIT to allow disabling compinit in cases where you want to skip them for secure reasons. For example when you login as a root.