### PR TITLE
regex-replace wasnt working on the positional argument

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -36,7 +36,7 @@ fi
     # Remove characters from a url that don't work well in a filename.
     # Inspired by -anti-get-clone-dir() method from antigen.
     autoload -U regexp-replace
-    url=$1
+    local url="${1}"
     regexp-replace url '/' '-SLASH-'
     regexp-replace url ':' '-COLON-'
     regexp-replace url '\|' '-PIPE-'

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -36,10 +36,11 @@ fi
     # Remove characters from a url that don't work well in a filename.
     # Inspired by -anti-get-clone-dir() method from antigen.
     autoload -U regexp-replace
-    regexp-replace 1 '/' '-SLASH-'
-    regexp-replace 1 ':' '-COLON-'
-    regexp-replace 1 '\|' '-PIPE-'
-    echo $1
+    url=$1
+    regexp-replace url '/' '-SLASH-'
+    regexp-replace url ':' '-COLON-'
+    regexp-replace url '\|' '-PIPE-'
+    echo $url
 }
 
 -zgen-get-clone-dir() {


### PR DESCRIPTION
I didn't find why regex-replace wasn't working with `$1`, but assigning the positional parameter into a new variable fixed it. [I'm using zgen to clone a github private repo through ssh, and it contained a colon]