### PR TITLE
Fixing issue in `zgen-save` after cleanups from 43a9b47

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -281,9 +281,9 @@ zgen-save() {
     if [[ ${ZGEN_USE_PREZTO} == 1 ]]; then
         -zginit ""
         -zginit "# ### Prezto modules"
-        printf %s\\n "pmodload" >> "${ZGEN_INIT}"
+        printf %s "pmodload" >> "${ZGEN_INIT}"
         for module in "${ZGEN_PREZTO_LOAD[@]}"; do
-            printf %s\\n " ${module}" >> "${ZGEN_INIT}"
+            printf %s " ${module}" >> "${ZGEN_INIT}"
         done
     fi
 


### PR DESCRIPTION
After updating `zgen` recently, I ran across an issue when initializing my zgen environment after a `zgen reset`. I got the following error message after the `zen-save` ran, then I closed my terminal, then opened it up again:

```
/Users/Jake/.zgen/init.zsh:25: command not found: environment
/Users/Jake/.zgen/init.zsh:26: command not found: archive
/Users/Jake/.zgen/init.zsh:27: command not found: completion
...
/Users/Jake/.zgen/init.zsh:fc:29: no such event: 1
```

I used `git bisect` to track own the issue, and it looks like it came from https://github.com/tarjoilija/zgen/commit/ca19ec2d30cb5ff82b32dc5472f36d7a7b471ac4, specifically the changes at https://github.com/tarjoilija/zgen/commit/ca19ec2d30cb5ff82b32dc5472f36d7a7b471ac4#diff-480111435108696ec148927533455158L256. It looks like the old functionality used the `-n` flag to `echo` (prevents the creation of a new line), while the new functionality clearly adds new lines after each entry in that step.

This PR fixes the issue by returning to the previous behavior of writing those lines separated by spaces rather than newlines.