### PR TITLE
Update zgen.zsh

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -260,7 +260,7 @@ zgen-save() {
 
         local ages="$(stat -Lc "%Y" 2>/dev/null $ZGEN_RESET_ON_CHANGE || \
                       stat -Lf "%m" 2>/dev/null $ZGEN_RESET_ON_CHANGE)"
-        local shas="$(shasum -a 256 ${ZGEN_RESET_ON_CHANGE})"
+        local shas="$(sha256sum ${ZGEN_RESET_ON_CHANGE})"
 
         -zginit "read -rd '' ages <<AGES; read -rd '' shas <<SHAS"
         -zginit "$ages"


### PR DESCRIPTION
Fix clean installation bug.
Error string: `.zgen/init.zsh:23: command not found: shasum`