### PR TITLE
Replace basename and dirname with parameter expansion

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -91,13 +91,13 @@ fi
     local branch="${2:-master}"
 
     if [[ -e "${repo}/.git" ]]; then
-        -zgputs "${ZGEN_DIR}/local/$(basename ${repo})-${branch}"
+        -zgputs "${ZGEN_DIR}/local/${repo:t}-${branch}"
     else
         # Repo directory will be location/reponame
-        local reponame="$(basename ${repo})"
+        local reponame="${repo:t}"
         # Need to encode incase it is a full url with characters that don't
         # work well in a filename.
-        local location="$(-zgen-encode-url $(dirname ${repo}))"
+        local location="$(-zgen-encode-url ${repo:h})"
         repo="${location}/${reponame}"
         -zgputs "${ZGEN_DIR}/${repo}-${branch}"
     fi
@@ -152,7 +152,7 @@ zgen-clone() {
         ZGEN_LOADED+=("${file}")
         source "${file}"
 
-        completion_path="$(dirname ${file})"
+        completion_path="${file:h}"
 
         -zgen-add-to-fpath "${completion_path}"
     fi
@@ -475,7 +475,7 @@ zgen-pmodule() {
         zgen-clone "${repo}" "${branch}"
     fi
 
-    local module=$(basename ${repo})
+    local module="${repo:t}"
 
     local preztodir="${ZDOTDIR:-$HOME}/.zprezto/modules/${module}"
     if [[ ! -h ${preztodir} ]]; then


### PR DESCRIPTION
This replaces `basename` and `dirname` with equivalent parameter expansions (`${var:t}` and `${var:h}` respectively) mainly for speed.

For benchmarking I measured zsh startup time with the following `.zshrc` (though this is an extreme case).

```zsh
# .zshrc
for i in {1..100}; do
  source ~/.zgen/zgen.zsh
done
```

As a result, startup time was reduced by about 40%.
```
# before
$ /usr/bin/time zsh -cli 'exit 0'
        1.58 real         0.58 user         0.86 sys

# after
$ /usr/bin/time zsh -cli 'exit 0'
        0.94 real         0.37 user         0.56 sys
```