### PR TITLE
Fix Prezto module loading order

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -267,7 +267,7 @@ zgen-save() {
     #       available flags are meaningless in the presence of `-C`.
     -zginit ""
     -zginit "# ### Plugins & Completions"
-    -zginit 'fpath=('"${(@q)ZGEN_COMPLETIONS}"' ${fpath})'
+    -zginit 'fpath=('"${(@qOa)ZGEN_COMPLETIONS}"' ${fpath})'
     if [[ ${ZGEN_AUTOLOAD_COMPINIT} == 1 ]]; then
         -zginit ""
         -zginit 'autoload -Uz compinit && \'

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -237,6 +237,23 @@ zgen-save() {
         for option in "${ZGEN_PREZTO_OPTIONS[@]}"; do
             -zginit "${option}"
         done
+
+        # Check if prezto main module is first in ZGEN_LOADED
+        # Load it before loading the rest of the prezto modules
+        if [[ ${ZGEN_LOADED[1]} =~ "prezto-master/init.zsh" ]]; then
+            # Source it and remove from array
+            -zginit 'source "'"${(q)ZGEN_LOADED[1]}"\"
+            ZGEN_LOADED[1]=()
+        fi
+
+        # load prezto modules
+        -zginit ""
+        -zginit "# ### Prezto modules"
+        printf %s "pmodload" >> "${ZGEN_INIT}"
+        for module in "${ZGEN_PREZTO_LOAD[@]}"; do
+            printf %s " ${module}" >> "${ZGEN_INIT}"
+        done
+        -zginit ""
     fi
 
     -zginit ""
@@ -281,17 +298,6 @@ zgen-save() {
         -zginit 'fi'
     fi
 
-    # load prezto modules
-    if [[ ${ZGEN_USE_PREZTO} == 1 ]]; then
-        -zginit ""
-        -zginit "# ### Prezto modules"
-        printf %s "pmodload" >> "${ZGEN_INIT}"
-        for module in "${ZGEN_PREZTO_LOAD[@]}"; do
-            printf %s " ${module}" >> "${ZGEN_INIT}"
-        done
-    fi
-
-    -zginit ""
     -zginit "# }}}"
 
     zgen-apply


### PR DESCRIPTION
I found a relatively simple and succinct way to fix the module loading order problem.  

Note that this will only work if `zgen prezto` is first in the list of commands, but if people put other modules first they are probably asking for trouble anyway.  

Another issue is that I don't particularly like matching on the specific string 'prezto-master/init.zsh', but that seems unlikely to change, and if it does its a simple fix to change it to the correct name.

This does fix the module loading order problem by making sure all prezto modules are loaded before any other plugins that may depend on them, without overwriting functions and aliases set in other plugins.