### PR TITLE
Enable extended_glob in zgen-update

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -215,6 +215,7 @@ zgen-reset() {
 }
 
 zgen-update() {
+    setopt localoptions extended_glob
     for repo in "${ZGEN_DIR}"/(^.git)/*; do
         -zgpute "Updating '${repo}' ..."
         (cd "${repo}" \


### PR DESCRIPTION
I don't have `setopt extended_glob` on my system. Because of this and 922e92e35094b3b856940f73ed3e3fd2ae84e9e7 in #95, `zgen update` fails with the following error:
```
zgen-update:1: no matches found: /home/user/.zgen/(^.git)/*
```

This fixes the issue by enabling `extended_glob` in `zgen-update` only.