### PR TITLE
Clarify default behavior of prezto modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ This will create a symlink in the `ZSHDOT` or `HOME` directory. This is needed b
 
 This uses the Prezto method for loading modules.
 
+**Note**: Some modules from prezto are enabled by default. Use `ZGEN_PREZTO_LOAD_DEFAULT=0` to disable this behavior.
+
 #### Load a repo as Prezto plugins
 
     zgen pmodule <reponame> <branch>


### PR DESCRIPTION
Notice users that some prezto modules are enabled by default, which is a default behavior of zgen. And tell how to disable this behavior.