### PR TITLE
Fix assignment of variable ZSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ It's a good idea to load the base components before specifying any plugins.
 
 This will create a symlink in the `ZSHDOT` or `HOME` directory. This is needed by prezto.
 
+**Note**: When `zgen prezto` is used with `zgen oh-my-zsh` together, `zgen prezto` should be **put behind** the other. Or prompt theme from prezto may not display as expected.
+
 #### Load prezto plugins
 
     zgen prezto <modulename>

--- a/zgen.zsh
+++ b/zgen.zsh
@@ -316,11 +316,7 @@ zgen-apply() {
 }
 
 -zgen-get-zsh(){
-    if [[ ${ZGEN_USE_PREZTO} == 1 ]]; then
-        -zgputs "$(-zgen-get-clone-dir "$ZGEN_PREZTO_REPO" "$ZGEN_PREZTO_BRANCH")"
-    else
-        -zgputs "$(-zgen-get-clone-dir "$ZGEN_OH_MY_ZSH_REPO" "$ZGEN_OH_MY_ZSH_BRANCH")"
-    fi
+    -zgputs "$(-zgen-get-clone-dir "$ZGEN_OH_MY_ZSH_REPO" "$ZGEN_OH_MY_ZSH_BRANCH")"
 }
 
 zgen-load() {


### PR DESCRIPTION
Details about this in #111.

 In short, prezto doesn't use `ZSH` variable at all. Only oh-my-zsh needs this variable `ZSH`. If `ZSH` directs to path of prezto, error occurs during loading of oh-my-zsh:

```shell
/Users/<username>/.zgen/robbyrussell/oh-my-zsh-master/oh-my-zsh.sh:34: no matches found: /Users/<username>/.zgen/sorin-ionescu/prezto-master/lib/*.zsh
```

And here is where the error above occurred,

```shell
# from oh-my-zsh.sh, starts at line 32
# Load all of the config files in ~/oh-my-zsh that end in .zsh
# TIP: Add files you don't want in git to .gitignore
for config_file ($ZSH/lib/*.zsh); do
  custom_config_file="${ZSH_CUSTOM}/lib/${config_file:t}"
  [ -f "${custom_config_file}" ] && config_file=${custom_config_file}
  source $config_file
done
```

So, `ZSH` should always directs to path of oh-my-zsh repo. 

Besides, in `init.zsh` generated by zgen, `sorin-ionescu/prezto-master/init.zsh` should be sourced after `robbyrussell/oh-my-zsh-master/oh-my-zsh.sh`. Or prompt theme from prezto module named prompt may failed to be loaded. This could be achieved in configuration file, by writing `zgen prezto` after `zgen oh-my-zsh`, which tip I added into `README.md`.