### PR TITLE
Update to new official ohmyzsh repo

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -53,7 +53,7 @@ if [[ -z "${ZGEN_PREZTO_LOAD_DEFAULT}" ]]; then
 fi
 
 if [[ -z "${ZGEN_OH_MY_ZSH_REPO}" ]]; then
-    ZGEN_OH_MY_ZSH_REPO=robbyrussell
+    ZGEN_OH_MY_ZSH_REPO=ohmyzsh/ohmyzsh
 fi
 
 if [[ "${ZGEN_OH_MY_ZSH_REPO}" != */* ]]; then


### PR DESCRIPTION
- Personal forks will remain the old default "oh-my-zsh" instead of the new dashless "ohmyzsh" if ZGEN_OH_MY_ZSH_REPO is set to just a user.
- Using a fully qualified omz repo name (ie: user/ohmyzsh) can use the new dashless naming.