### PR TITLE
Avoid loading autoloaded file

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -148,8 +148,9 @@ zgen-clone() {
 
 -zgen-source() {
     local file="${1}"
+    local base=$(basename "${file}")
 
-    if [[ ! "${ZGEN_LOADED[@]}" =~ "${file}" ]]; then
+    if [[ ! "${base}" =~ "^_" && ! "${ZGEN_LOADED[@]}" =~ "${file}" ]]; then
         ZGEN_LOADED+=("${file}")
         source "${file}"
 


### PR DESCRIPTION
In zsh file name convention, file name of which starts with '_' is
an autoloaded file. It should not be loaded manually.

This fixes https://github.com/zsh-users/zsh-completions/issues/809